### PR TITLE
Add sign arguments to `create` and `read`

### DIFF
--- a/src/create.ts
+++ b/src/create.ts
@@ -1,3 +1,4 @@
+import type { SignOptions } from '@balena/resource-bundle';
 import {
 	docker,
 	create as createResourceBundle,
@@ -14,6 +15,7 @@ export async function create(
 	state: any,
 	images: ImageDescriptor[],
 	creds?: Credentials,
+	sign?: SignOptions,
 ) {
 	const token = await authenticate(images, creds);
 
@@ -26,6 +28,7 @@ export async function create(
 			images: res.images,
 		},
 		resources: res.blobs,
+		sign,
 	});
 }
 

--- a/src/read.ts
+++ b/src/read.ts
@@ -7,10 +7,12 @@ import { BALENA_UPDATE_TYPE } from './types';
 
 export async function read(
 	input: stream.Readable,
+	publicKey?: string,
 ): Promise<ReadableUpdateBundle> {
 	const update = await readResourceBundle<UpdateBundleManifest>(
 		input,
 		BALENA_UPDATE_TYPE,
+		publicKey,
 	);
 
 	const { state, images } = update.manifest;


### PR DESCRIPTION
This mirrors the `create` and `read` API of `@balena/resource-bundle` by introducing the same arguments for signing the resource bundle.
