### PR TITLE
Do not require credentials on registry auth

### DIFF
--- a/src/create.ts
+++ b/src/create.ts
@@ -42,12 +42,6 @@ async function authenticate(
 		return;
 	}
 
-	if (creds == null) {
-		throw new Error(
-			'Docker registry requires authentication, but credentials were not provided',
-		);
-	}
-
 	const [auth, scope] = authResult;
 
 	return await docker.authenticate(auth, scope, creds);


### PR DESCRIPTION
Allows authenticating to registries that do not require credentials like Docker Hub.
