### PR TITLE
Fetching devices and fleet target state

### DIFF
--- a/src/read.ts
+++ b/src/read.ts
@@ -15,9 +15,9 @@ export async function read(
 		publicKey,
 	);
 
-	const { state, images } = update.manifest;
+	const manifest = update.manifest;
 
-	const archive = new docker.DockerArchive(images);
+	const archive = new docker.DockerArchive(manifest.images);
 
 	for (const resource of update.resources) {
 		if (archive.containsImageBlob(resource)) {
@@ -27,5 +27,5 @@ export async function read(
 		throw new Error(`Found unexpected resource in bundle: ${resource.id}`);
 	}
 
-	return { state, images, archive: archive.finalize() };
+	return { manifest, archive: archive.finalize() };
 }

--- a/src/state.ts
+++ b/src/state.ts
@@ -1,0 +1,165 @@
+import { docker } from '@balena/resource-bundle';
+
+import type {
+	ImageDescriptor,
+	DeviceConfig,
+	FleetConfig,
+	FetchTargetStateResult,
+} from './types';
+
+const BALENA_API = 'https://api.balena-cloud.com';
+
+function getAPIHeaders(token: string) {
+	return {
+		'Content-Type': 'application/json',
+		Authorization: `Bearer ${token}`,
+		'Accept-Encoding': 'gzip',
+	};
+}
+
+export interface DeviceStateV3 {
+	[deviceUuid: string]: {
+		name?: string;
+		config: {
+			[key: string]: string;
+		};
+		apps: {
+			[appUuid: string]: {
+				release_uuid?: string;
+				releases: {
+					[releaseUuid: string]: {
+						services: {
+							[serviceName: string]: {
+								image: string;
+							};
+						};
+					};
+				};
+			};
+		};
+	};
+}
+
+export function listImagesFromTargetState(
+	targetState: DeviceStateV3,
+): ImageDescriptor[] {
+	const images = [];
+
+	for (const device of Object.values(targetState)) {
+		for (const app of Object.values(device.apps)) {
+			for (const release of Object.values(app.releases)) {
+				for (const service of Object.values(release.services)) {
+					images.push(docker.parseImageName(service.image));
+				}
+			}
+		}
+	}
+
+	return images;
+}
+
+function addImage(
+	image: ImageDescriptor,
+	deduplicatedImages: ImageDescriptor[],
+) {
+	for (const existingImage of deduplicatedImages) {
+		if (
+			image.reference === existingImage.reference &&
+			image.registry === existingImage.registry &&
+			image.repository === existingImage.repository
+		) {
+			return;
+		}
+	}
+
+	deduplicatedImages.push(image);
+}
+
+export async function fetchDevicesTargetStates(
+	deviceUUIDs: string[],
+	token: string,
+): Promise<FetchTargetStateResult> {
+	const config: DeviceConfig[] = [];
+	const deduplicatedImages: ImageDescriptor[] = [];
+
+	for (const uuid of deviceUUIDs) {
+		const state = await fetchSingleDeviceTargetState(uuid, token);
+
+		for (const image of listImagesFromTargetState(state)) {
+			addImage(image, deduplicatedImages);
+		}
+
+		config.push({
+			deviceUuid: uuid,
+			version: '3',
+			state,
+		});
+	}
+
+	return {
+		type: 'Devices',
+		config,
+		images: deduplicatedImages,
+	};
+}
+
+async function fetchSingleDeviceTargetState(
+	device: string,
+	token: string,
+): Promise<DeviceStateV3> {
+	const url = `${BALENA_API}/device/v3/${device}/state`;
+
+	const response = await fetch(url, {
+		method: 'GET',
+		headers: getAPIHeaders(token),
+	});
+
+	if (response.body == null) {
+		throw new Error(`Empty device target state for ${device}`);
+	}
+
+	return await response.json();
+}
+
+export async function fetchFleetTargetState(
+	appUuid: string,
+	token: string,
+	releaseUuid?: string,
+): Promise<FetchTargetStateResult> {
+	let releaseParam: string;
+	if (releaseUuid == null) {
+		releaseParam = '';
+	} else {
+		releaseParam = releaseUuid;
+	}
+
+	const url = `${BALENA_API}/device/v3/fleet/${appUuid}/state/?releaseUuid=${releaseParam}`;
+
+	const response = await fetch(url, {
+		method: 'GET',
+		headers: getAPIHeaders(token),
+	});
+
+	if (response.body == null) {
+		throw new Error(
+			`Empty application target state for ${appUuid} and ${releaseUuid}`,
+		);
+	}
+
+	const state = await response.json();
+
+	const config: FleetConfig = {
+		appUuid,
+		releaseUuid,
+		version: '3',
+		state,
+	};
+
+	const images = listImagesFromTargetState(state);
+
+	return {
+		type: 'Fleet',
+		config,
+		images,
+	};
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,6 @@
 import type * as stream from 'node:stream';
 
+import type { SignOptions } from '@balena/resource-bundle';
 import { docker } from '@balena/resource-bundle';
 
 export const BALENA_UPDATE_TYPE = 'io.balena.update@1';
@@ -12,13 +13,80 @@ export import ImageManifest = docker.ImageManifest;
 export import ImageDescriptor = docker.ImageDescriptor;
 export import Image = docker.Image;
 
-export interface UpdateBundleManifest {
-	state: any;
+interface BaseManifest {
+	type: string;
+	config: any;
 	images: Image[];
 }
 
+interface BaseTargetState {
+	version: string;
+	state: any;
+}
+
+export interface DeviceConfig extends BaseTargetState {
+	deviceUuid: string;
+}
+
+export interface FleetConfig extends BaseTargetState {
+	appUuid: string;
+	releaseUuid?: string;
+}
+
+export interface DevicesUpdateManifest extends BaseManifest {
+	type: 'Devices';
+	config: DeviceConfig[];
+}
+
+export interface FleetUpdateManifest extends BaseManifest {
+	type: 'Fleet';
+	config: FleetConfig;
+}
+
+export type UpdateBundleManifest = DevicesUpdateManifest | FleetUpdateManifest;
+
+interface BaseCreateOptions {
+	type: string;
+	auth: BearerAuth;
+	sign?: SignOptions;
+}
+
+export interface DevicesUpdateCreateOptions extends BaseCreateOptions {
+	type: 'Devices';
+	deviceUuids: string[];
+}
+
+export interface FleetUpdateCreateOptions extends BaseCreateOptions {
+	type: 'Fleet';
+	appUuid: string;
+	releaseUuid?: string;
+}
+
+export type UpdateCreateOptions =
+	| DevicesUpdateCreateOptions
+	| FleetUpdateCreateOptions;
+
+interface BaseTargetStateResult {
+	type: string;
+	config: any;
+	images: ImageDescriptor[];
+}
+
+export interface DevicesFetchTargetStateResult extends BaseTargetStateResult {
+	type: 'Devices';
+	config: DeviceConfig[];
+}
+
+export interface FleetFetchTargetStateResult extends BaseTargetStateResult {
+	type: 'Fleet';
+	config: FleetConfig;
+}
+
+export type FetchTargetStateResult =
+	| DevicesFetchTargetStateResult
+	| FleetFetchTargetStateResult;
+
 export interface ReadableUpdateBundle {
-	readonly state: any;
-	readonly images: Image[];
+	readonly manifest: UpdateBundleManifest;
 	readonly archive: stream.Readable;
 }

--- a/test/all.spec.ts
+++ b/test/all.spec.ts
@@ -8,15 +8,7 @@ chai.use(chaiAsPromised);
 const expect = chai.expect;
 
 describe('common usage', () => {
-	it('create bundle with no images and read it', async () => {
-		const updateStream = await bundle.create({ hello: 'world' }, []);
-		updateStream.resume();
-
-		const readableBundle = await bundle.read(updateStream);
-
-		readableBundle.archive.resume();
-
-		expect(readableBundle.state).to.eql({ hello: 'world' });
-		expect(readableBundle.images).to.eql([]);
+	it('inspect balena update type', async () => {
+		expect(bundle.BALENA_UPDATE_TYPE).to.eql('io.balena.update@1');
 	});
 });


### PR DESCRIPTION
Added ability to fetch target state for an array of balena devices or a specific fleet target state.

The create API is improved now, so this is considered a breaking change.
